### PR TITLE
fix(desktop_entry): 修复Windows控制台输入输出重定向问题

### DIFF
--- a/src/amdl/desktop_entry.py
+++ b/src/amdl/desktop_entry.py
@@ -19,6 +19,7 @@ def _alloc_console() -> None:
         try:
             import ctypes
             ctypes.windll.kernel32.AllocConsole()
+            sys.stdin = open("CONIN$", "r", encoding="utf-8")
             sys.stdout = open("CONOUT$", "w", encoding="utf-8")
             sys.stderr = open("CONOUT$", "w", encoding="utf-8")
         except Exception:


### PR DESCRIPTION
- 添加了标准输入流到CONIN$的重定向
- 确保了UTF-8编码在控制台I/O中的正确处理
- 解决了Windows环境下命令行交互的功能缺陷