### PR TITLE
feat(cli): 支持带选项下载 Apple Music 播放列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ amdl -c /path/to/cookies.txt "https://music.apple.com/cn/album/left-and-right/16
 # 下载整张专辑
 amdl -c /path/to/cookies.txt "https://music.apple.com/cn/album/left-and-right/1630451412"
 
+# 下载完整播放列表（自动展开并下载全部可用歌曲）
+amdl -c /path/to/cookies.txt \
+  "https://music.apple.com/cn/playlist/playlist-name/pl.1234567890abcdef1234567890abcdef"
+
 # 指定输出目录
 amdl -c /path/to/cookies.txt -o "./My Music" "https://music.apple.com/..."
 

--- a/README_en.md
+++ b/README_en.md
@@ -100,6 +100,10 @@ amdl -c /path/to/cookies.txt "https://music.apple.com/us/album/left-and-right/16
 # Download an entire album
 amdl -c /path/to/cookies.txt "https://music.apple.com/us/album/left-and-right/1630451412"
 
+# Download a complete playlist (automatically expands and downloads all available tracks)
+amdl -c /path/to/cookies.txt \
+  "https://music.apple.com/us/playlist/playlist-name/pl.1234567890abcdef1234567890abcdef"
+
 # Specify output directory
 amdl -c /path/to/cookies.txt -o "./My Music" "https://music.apple.com/..."
 

--- a/src/amdl/cli.py
+++ b/src/amdl/cli.py
@@ -74,7 +74,7 @@ def main() -> None:
         return
 
     # ── new sub-command style ──────────────────────────────────
-    if args and args[0] not in ("--help", "-h", "--version") and not args[0].startswith("-"):
+    if args and args[0] not in ("--help", "-h", "--version"):
         # Could be a sub-command (server/desktop) or gamdl passthrough
         if args[0] in ("server", "desktop"):
             cli(args=args, standalone_mode=False)
@@ -104,7 +104,7 @@ AppleMusic Downloader (amdl) v{__version__}
 Usage:
   amdl server [--host HOST] [--port PORT]   Start API server
   amdl desktop                               Launch desktop app
-  amdl <gamdl args...>                       Pass through to gamdl CLI
+  amdl <gamdl args...>                       Download songs, albums or playlists
 
 Server options:
   --host HOST        Listen address (default: 127.0.0.1)
@@ -115,6 +115,6 @@ Examples:
   amdl server --host 0.0.0.0 --port 8000
   amdl desktop
   amdl -c /path/to/cookies.txt "https://music.apple.com/..."
+  amdl -c /path/to/cookies.txt "https://music.apple.com/.../playlist/.../pl..."
   amdl --help
 """
-    

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from amdl import cli as cli_module
+
+
+PLAYLIST_URL = (
+    "https://music.apple.com/us/playlist/test/"
+    "pl.1234567890abcdef1234567890abcdef"
+)
+
+
+class CliRoutingTests(unittest.TestCase):
+    def test_gamdl_arguments_are_forwarded_unchanged(self) -> None:
+        invocations = [
+            [PLAYLIST_URL],
+            ["-c", "/tmp/cookies.txt", PLAYLIST_URL],
+            ["-c", "/tmp/cookies.txt", "-o", "/tmp/music", PLAYLIST_URL],
+        ]
+
+        for args in invocations:
+            with self.subTest(args=args):
+                with (
+                    patch.object(sys, "argv", ["amdl", *args]),
+                    patch.object(cli_module, "_passthrough_to_gamdl") as passthrough,
+                ):
+                    cli_module.main()
+
+                passthrough.assert_called_once_with(args)
+
+    def test_local_commands_are_not_forwarded(self) -> None:
+        for command in ("server", "desktop", "--version"):
+            with self.subTest(command=command):
+                with (
+                    patch.object(sys, "argv", ["amdl", command]),
+                    patch.object(cli_module, "cli") as local_cli,
+                    patch.object(cli_module, "_passthrough_to_gamdl") as passthrough,
+                ):
+                    cli_module.main()
+
+                local_cli.assert_called_once_with(
+                    args=[command], standalone_mode=False
+                )
+                passthrough.assert_not_called()
+
+    def test_help_is_not_forwarded(self) -> None:
+        with (
+            patch.object(sys, "argv", ["amdl", "--help"]),
+            patch.object(cli_module.click, "echo") as echo,
+            patch.object(cli_module, "_passthrough_to_gamdl") as passthrough,
+        ):
+            cli_module.main()
+
+        echo.assert_called_once_with(cli_module._HELP)
+        passthrough.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修改原因
当前 CLI 仅在链接作为第一个参数时才会透传给 gamdl
比如

```bash
amdl -c /path/to/cookies.txt PLAYLIST_URL
```

会因为首个参数是 -c 而被 AMDL 自身的 Click 命令错误处理，最终提示 No such option '-c'

## 修改内容
- 修复 CLI 参数分流，使 -c、-o 等 gamdl 选项可以正常透传
- 在中英文 README 和 CLI help 中补充播放列表下载示例
- 新增 CLI 路由回归测试